### PR TITLE
Add missing import to generate method

### DIFF
--- a/openapi/codegen.nim
+++ b/openapi/codegen.nim
@@ -1419,6 +1419,7 @@ proc consume*(generator: var Generator; content: string) {.compileTime.} =
 template generate*(name: untyped; input: string; output: string; body: untyped): untyped {.dirty.} =
   ## parse input json filename and output nim target library
   import macros
+  import strutils
 
   macro name(embody: untyped): untyped =
     var generator = newGenerator(inputfn= input, outputfn= output)


### PR DESCRIPTION
Odds are the parent program is already doing a `import strutils`. But if not, the `generate` macro will fail with a message saying:

```txt
{redacted}/openapistuff/test.nim(7, 10) template/generic instantiation of `generate` from here
{redacted}/.nimble/pkgs/openapi-4.0.0/openapi/codegen.nim(1435, 30) Error: attempting to call undeclared routine: 'endsWith'
```

Simply adding that include to the macro fixes that.

an example program that will fail:

```nim
import openapi/codegen

generate myAPI, "{redacted}/openapistuff/input.json", "{redacted}/openapistuff/output.nim":
  discard
render myAPI:
  discard
```